### PR TITLE
Update terminology from 'deaf-mute' to 'deaf'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # exPress (Web)
-## A Mobile Application for Seamless Communication Between Abled and Deaf-Mute Individuals
+## A Mobile Application for Seamless Communication Between Abled and Deaf Individuals
 
 ### National University of Dasmariñas: Capstone Project
 
@@ -14,7 +14,7 @@
 
 ## Overview
 
-**exPress** is a mobile application designed to allow abled people to connect within deaf-mute communities seamlessly and vice-versa. With features like sign language to text and text/audio to sign language conversion, exPress breaks down the barrier between abled people and deaf-mute individuals.
+**exPress** is a mobile application designed to allow abled people to connect within deaf communities seamlessly and vice-versa. With features like sign language to text and text/audio to sign language conversion, exPress breaks down the barrier between abled people and deaf individuals.
 
 ---
 
@@ -62,7 +62,7 @@
 
 ## Usage
 
-This project is currently a web-based frontend for the exPress application. It demonstrates the UI and navigation for both abled and deaf-mute users, including admin and user dashboards, sign language resources, and translation features (to be integrated).
+This project is currently a web-based frontend for the exPress application. It demonstrates the UI and navigation for both abled and deaf users, including admin and user dashboards, sign language resources, and translation features (to be integrated).
 
 ---
 

--- a/webexpress/src/user/UserAboutPage.jsx
+++ b/webexpress/src/user/UserAboutPage.jsx
@@ -16,7 +16,7 @@ const UserAboutPage = () => {
           <p>
             Version: v1.1.0<br />
             Release Date: September 16, 2025<br /><br />
-            exPress is a communication app designed to bridge the gap between the deaf-mute community 
+            exPress is a communication app designed to bridge the gap between the deaf community 
             and the general public. It offers real-time speech-to-text and text-to-speech functionalities, 
             making conversations seamless and inclusive.<br /><br />
             <span style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '8px' }}>
@@ -38,12 +38,12 @@ const UserAboutPage = () => {
             We are the team behind exPress—Alyssa, Aisha, and Iver, a group of developers, innovators, 
             and advocates for inclusivity. Our journey began with one simple question: how can technology 
             help break down the barriers that keep people from understanding one another?<br /><br />
-            We realized that communication challenges, especially for the deaf-mute community, often go unnoticed. 
+            We realized that communication challenges, especially for the deaf community, often go unnoticed. 
             Many people struggle to express themselves or be understood, simply because sign language is not universally known. 
             This inspired us to create exPress, a tool that empowers individuals to connect, learn, and communicate without limits.<br /><br />
             We combined global and local knowledge by training our models with international sign language datasets from Kaggle 
             and Filipino Sign Language data from Mendeley to ensure accuracy and relevance for the Filipino community.<br /><br />
-            Our mission: Develop innovative technologies that empower the deaf-mute community and foster inclusive communication for all.<br /><br />
+            Our mission: Develop innovative technologies that empower the deaf community and foster inclusive communication for all.<br /><br />
             Our vision: A future where communication knows no limits, where exPress serves as both a tool and movement toward universal inclusivity.<br /><br />
             Our values: Inclusivity, purposeful innovation, community-first mindset, and empowerment guide everything we do.
           </p>

--- a/webexpress/src/user/UserHelpPage.jsx
+++ b/webexpress/src/user/UserHelpPage.jsx
@@ -17,7 +17,7 @@ const UserHelpPage = () => {
             <strong>What is exPress?</strong><br />
             - exPress is a mobile and web-based communication tool that translates sign language 
             into text and text or audio into sign language animations, helping bridge conversations 
-            between deaf-mute individuals and non-signers.<br /><br />
+            between deaf individuals and non-signers.<br /><br />
 
             <strong>Is exPress an e-learning app?</strong><br />
             - No. exPress is not an e-learning platform. Its main purpose is to support real-time 

--- a/webexpress/src/user/UserHome.jsx
+++ b/webexpress/src/user/UserHome.jsx
@@ -116,7 +116,7 @@ export default function UserHome() {
 
               {/* Video */}
               <div className="express-demo-video-wrapper">
-                <video src={expressVideo} className="express-demo-video" controls muted />
+                <video src={expressVideo} className="express-demo-video" controls />
               </div>
             </div>
 


### PR DESCRIPTION
Replaced all instances of 'deaf-mute' with 'deaf' in README and user-facing pages for more accurate and respectful language. Also removed the 'muted' attribute from the demo video in UserHome.jsx to allow audio playback.